### PR TITLE
Introduce `.circleci/config.yml` config for automatic testing of python versions.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,48 @@
+defaults: &defaults
+  steps:
+      - checkout
+      - run: pip install .
+      - run: python -m unittest discover tests
+
+version: 2.1
+jobs:
+  python_2-7:
+    working_directory: ~/temptracker
+    docker:
+      - image: circleci/python:2.7
+    <<: *defaults
+  python_3-5:
+    working_directory: ~/temptracker
+    docker:
+      - image: circleci/python:3.5
+    <<: *defaults
+  python_3-6:
+    working_directory: ~/temptracker
+    docker:
+      - image: circleci/python:3.6
+    <<: *defaults
+  python_3-7:
+    working_directory: ~/temptracker
+    docker:
+      - image: circleci/python:3.7
+    <<: *defaults
+  python_3-8:
+    working_directory: ~/temptracker
+    docker:
+      - image: circleci/python:3.8
+    <<: *defaults
+  python_3-9:
+    working_directory: ~/temptracker
+    docker:
+      - image: circleci/python:3.9
+    <<: *defaults
+workflows:
+  version: 2.1
+  test_python_versions:
+    jobs:
+      - python_2-7
+      - python_3-5
+      - python_3-6
+      - python_3-7
+      - python_3-8
+      - python_3-9

--- a/setup.py
+++ b/setup.py
@@ -10,26 +10,21 @@ setuptools.setup(
     author_email="jacob@magnetic-lab.com",
     description="A test application for recording and performing math on temperature readings.",
     license="GNU General Public License v3 or later (GPLv3+)",
-     platforms=["POSIX", "Windows"],
-     py_modules=["temptracker"],
+    platforms=["POSIX", "Windows"],
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/jacobmartinez3d/temptracker",
     packages=setuptools.find_packages(include="temptracker"),
     classifiers=[
-             "Development Status :: 2 - Pre-Alpha",
+            "Development Status :: 2 - Pre-Alpha",
             "Programming Language :: Python :: 2.7",
-            "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.1",
-            "Programming Language :: Python :: 3.2",
-            "Programming Language :: Python :: 3.3",
-            "Programming Language :: Python :: 3.4",
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
             "Operating System :: Microsoft :: Windows",
             "Operating System :: POSIX"
     ],
-    python_requires=">=2.7, <3.9"
+    python_requires=">=2.7, <=3.9"
 )


### PR DESCRIPTION
This pull request introduces CircleCI's automatic continuous-integration features upon pushing to any branches in this repository.

Upon each new push, python versions 2.7, 3.5, 3.6, 3.7, 3.8, 3.9 will be used to install and run the supplied tests using `unittest`.